### PR TITLE
Alternative solution for issue #5 implemented

### DIFF
--- a/_layouts/default-sidebar.html
+++ b/_layouts/default-sidebar.html
@@ -7,7 +7,7 @@ layout: default
     <!-- left pane -->
     <div class="col-4">
       <div class="row col-12">
-        <h3>OFK Training series</h3> 
+        <h3>OKF Training series</h3> 
       </div>
       {% assign serieslist = site.pages | where: "layout", "series" | sort: "title" %}
       {% for node in serieslist %}

--- a/index.html
+++ b/index.html
@@ -48,9 +48,48 @@ description: Upcoming and past training events from Open Knowledge activities an
             <span class="eventlisting-eventtitle">No current or upcoming events.</span></p>
     </div>
 </div>
-
 {% endif %}
 
+<h3>OKF events being planned</h3>
+
+{% assign eventlist = site.pages | where: "layout", "event" | sort: "date" | reverse %}
+{% capture now %}{{"now" | date: "%s" | plus: 0 }}{% endcapture %}
+{% capture lastdate %}{{eventlist.last.date | date: "%s" | plus: 0 }}{% endcapture %}
+{% if lastdate == "0" %}
+{% for node in eventlist %}
+{% capture date %}{{node.date | date: "%s" | plus: 0 }}{% endcapture %}
+{% if date == "0" %}
+{% if node.layout == "event" %}
+<div class="row eventlisting-container">
+    <div class="eventlisting">
+        <p class="eventlisting-eventdateandtitle" style="margin-top: 0px">
+            <!-- <span class="eventlisting-eventtitle">{{ node.title }}</span> -->
+            <span class="eventlisting-eventtitle"><a href="{{ site.baseurl }}{{ node.permalink }}" class="eventlisting-eventtitle">{{ node.title }}</a></span>
+            <p>
+                <span class="eventlisting-eventlocation" style="font-size: large; color: #4f4f4f; margin-left:0";>{{ node.location }}</span>
+            </p>
+        </p>
+        <p class="eventlisting-eventdescription">{{ node.description }}</p>
+        <a class="btn btn-primary btn-sm active" role="button" aria-pressed="true" href="{{ site.baseurl }}{{ node.permalink }}">Details</a>
+        <!-- {% if node.series %}
+        <p class="eventlisting-seriestitle">
+            An event in the <a href="{{ site.baseurl }}{{ node.serieslink }}">{{ node.series }}</a> series.
+        </p> -->
+        {% endif %}
+    </div>
+</div>
+{% endif %}
+{% endif %}
+{% endfor %}
+
+{% else %}
+<div class="row eventlisting-container">
+    <div class="eventlisting">
+        <p class="eventlisting-eventdateandtitle" style="margin-top: 0px">
+            <span class="eventlisting-eventtitle">No events being planned.</span></p>
+    </div>
+</div>
+{% endif %}
 
 <h3>OKF past events</h3>
 
@@ -58,7 +97,7 @@ description: Upcoming and past training events from Open Knowledge activities an
 {% capture now %}{{"now" | date: "%s" | plus: 0 }}{% endcapture %}
 {% for node in eventlist %}
 {% capture date %}{{node.date | date: "%s" | plus: 0 }}{% endcapture %}
-{% if date < now %}
+{% if date < now and date !="0" %}
 {% if node.layout == "event" %}
 <div class="row eventlisting-container">
     <div class="eventlisting">
@@ -72,7 +111,6 @@ description: Upcoming and past training events from Open Knowledge activities an
         </p>
         <p class="eventlisting-eventdescription">{{ node.description }}</p>
         <a class="btn btn-primary btn-sm active" role="button" aria-pressed="true" href="{{ site.baseurl }}{{ node.permalink }}">Details</a>
-       
         <!-- {% if node.series %}
         <p class="eventlisting-seriestitle">
             An event in the <a href="{{ site.baseurl }}{{ node.serieslink }}">{{ node.series }}</a> series.


### PR DESCRIPTION
- New category for "OKF events being planned" added
- Logic for the category implemented

Without planned event
<img width="931" alt="image" src="https://user-images.githubusercontent.com/3656268/188867874-b62c2e4b-9a98-43e3-9cac-25a5cca934c4.png">


With planned event, without a date
<img width="929" alt="image" src="https://user-images.githubusercontent.com/3656268/188867911-00a6f3da-26f1-4fb1-a9d9-77b5a605b92f.png">
