### PR TITLE
Limit the number of events and all events page created based on #6

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -2,9 +2,12 @@
   <div class="container">
     <nav class="primary-nav">
       <ul>
+        {% assign pagelist = site.pages | where: "permalink", "/allevents" %}
+        {% for node in pagelist%}
         <!-- <li><a href="https://okfn.org">Open Knowledge homepage</a></li> -->
-        <li><a href="{{ site.baseurl }}/">All training events</a></li>
+        <li><a href="{{ site.baseurl }}{{ node.permalink }}">All training events</a></li>
         <!-- <li><a href="{{ site.baseurl }}/series/">Series</a></li> -->
+        {% endfor %}
       </ul>
     </nav>
     <a class="header-logo" href="{{ site.baseurl }}/">

--- a/_layouts/default-sidebar.html
+++ b/_layouts/default-sidebar.html
@@ -7,7 +7,7 @@ layout: default
     <!-- left pane -->
     <div class="col-4">
       <div class="row col-12">
-        <h3>OFK Training series</h3> 
+        <h3>OKF Training series</h3> 
       </div>
       {% assign serieslist = site.pages | where: "layout", "series" | sort: "title" %}
       {% for node in serieslist %}

--- a/allevents.html
+++ b/allevents.html
@@ -1,0 +1,41 @@
+---
+layout: default-sidebar
+title: Open Knowledge events
+description: Upcoming and past training events from Open Knowledge activities and programmes.
+permalink: /allevents
+---
+
+{% assign eventlist = site.pages | where: "layout", "event" | sort: "date" %}
+{% capture now %}{{"now" | date: "%s" | plus: 0 }}{% endcapture %}
+
+<div class="right-pane-title row col-12">
+    <h3>OKF all training events</h3>
+</div>
+{% assign eventlist = site.pages | where: "layout", "event" | sort: "date" | reverse %}
+{% capture now %}{{"now" | date: "%s" | plus: 0 }}{% endcapture %}
+{% for node in eventlist %}
+{% capture date %}{{node.date | date: "%s" | plus: 0 }}{% endcapture %}
+{% if date %}
+{% if node.layout == "event" %}
+<div class="row eventlisting-container">
+    <div class="eventlisting">
+        <p class="eventlisting-eventdateandtitle" style="margin-top: 0px">
+            <!-- <span class="eventlisting-eventtitle">{{ node.title }}</span> -->
+            <span class="eventlisting-eventtitle"><a href="{{ site.baseurl }}{{ node.permalink }}" class="eventlisting-eventtitle">{{ node.title }}</a></span>
+            <p>
+                <span class="eventlisting-eventdate" style="font-size: large; color: #4f4f4f">{{ node.date | date: "%d %B %Y" }}</span>
+                <span class="eventlisting-eventlocation" style="font-size: large; color: #4f4f4f">{{ node.location }}</span>
+            </p>
+        </p>
+        <p class="eventlisting-eventdescription">{{ node.description }}</p>
+        <a class="btn btn-primary btn-sm active" role="button" aria-pressed="true" href="{{ site.baseurl }}{{ node.permalink }}">Details</a>
+        <!-- {% if node.series %}
+        <p class="eventlisting-seriestitle">
+            An event in the <a href="{{ site.baseurl }}{{ node.serieslink }}">{{ node.series }}</a> series.
+        </p> -->
+        {% endif %}
+    </div>
+</div>
+{% endif %}
+{% endif %}
+{% endfor %}

--- a/index.html
+++ b/index.html
@@ -13,7 +13,6 @@ description: Upcoming and past training events from Open Knowledge activities an
 
 {% capture lastdate %}{{eventlist.last.date | date: "%s" | plus: 0 }}{% endcapture %}
 {% if lastdate >= now %}
-
 {% for node in eventlist %}
 {% capture date %}{{node.date | date: "%s" | plus: 0 }}{% endcapture %}
 {% if date >= now %}
@@ -95,10 +94,15 @@ description: Upcoming and past training events from Open Knowledge activities an
 
 {% assign eventlist = site.pages | where: "layout", "event" | sort: "date" | reverse %}
 {% capture now %}{{"now" | date: "%s" | plus: 0 }}{% endcapture %}
+{% assign i = 0 %}
 {% for node in eventlist %}
+{% if i>=10 %}
+{% break %}
+{% endif %}
 {% capture date %}{{node.date | date: "%s" | plus: 0 }}{% endcapture %}
 {% if date < now and date !="0" %}
 {% if node.layout == "event" %}
+{% assign i=i | plus:1 %}
 <div class="row eventlisting-container">
     <div class="eventlisting">
         <p class="eventlisting-eventdateandtitle" style="margin-top: 0px">
@@ -120,4 +124,8 @@ description: Upcoming and past training events from Open Knowledge activities an
 </div>
 {% endif %}
 {% endif %}
+{% endfor %}
+{% assign pagelist = site.pages | where: "permalink", "/allevents" %}
+{% for node in pagelist%}
+<a class="btn btn-dark btn-sm active mx-xxl" style="margin-left: 50%; background: #DDE3EA; color: #22B7F8; padding: 10px 10px;" role="button" aria-pressed="true"  href="{{ site.baseurl }}{{ node.permalink }}">View all events</a>
 {% endfor %}

--- a/index.html
+++ b/index.html
@@ -48,9 +48,48 @@ description: Upcoming and past training events from Open Knowledge activities an
             <span class="eventlisting-eventtitle">No current or upcoming events.</span></p>
     </div>
 </div>
-
 {% endif %}
 
+<h3>OKF events being planned</h3>
+
+{% assign eventlist = site.pages | where: "layout", "event" | sort: "date" | reverse %}
+{% capture now %}{{"now" | date: "%s" | plus: 0 }}{% endcapture %}
+{% capture lastdate %}{{eventlist.last.date | date: "%s" | plus: 0 }}{% endcapture %}
+{% if lastdate == "0" %}
+{% for node in eventlist %}
+{% capture date %}{{node.date | date: "%s" | plus: 0 }}{% endcapture %}
+{% if date == "0" %}
+{% if node.layout == "event" %}
+<div class="row eventlisting-container">
+    <div class="eventlisting">
+        <p class="eventlisting-eventdateandtitle" style="margin-top: 0px">
+            <!-- <span class="eventlisting-eventtitle">{{ node.title }}</span> -->
+            <span class="eventlisting-eventtitle"><a href="{{ site.baseurl }}{{ node.permalink }}" class="eventlisting-eventtitle">{{ node.title }}</a></span>
+            <p>
+                <span class="eventlisting-eventlocation" style="font-size: large; color: #4f4f4f; margin-left:0";>{{ node.location }}</span>
+            </p>
+        </p>
+        <p class="eventlisting-eventdescription">{{ node.description }}</p>
+        <a class="btn btn-primary btn-sm active" role="button" aria-pressed="true" href="{{ site.baseurl }}{{ node.permalink }}">Details</a>
+        <!-- {% if node.series %}
+        <p class="eventlisting-seriestitle">
+            An event in the <a href="{{ site.baseurl }}{{ node.serieslink }}">{{ node.series }}</a> series.
+        </p> -->
+        {% endif %}
+    </div>
+</div>
+{% endif %}
+{% endif %}
+{% endfor %}
+
+{% else %}
+<div class="row eventlisting-container">
+    <div class="eventlisting">
+        <p class="eventlisting-eventdateandtitle" style="margin-top: 0px">
+            <span class="eventlisting-eventtitle">No events being planned.</span></p>
+    </div>
+</div>
+{% endif %}
 
 <h3>OKF past events</h3>
 
@@ -58,7 +97,7 @@ description: Upcoming and past training events from Open Knowledge activities an
 {% capture now %}{{"now" | date: "%s" | plus: 0 }}{% endcapture %}
 {% for node in eventlist %}
 {% capture date %}{{node.date | date: "%s" | plus: 0 }}{% endcapture %}
-{% if date < now %}
+{% if date < now and date !="0" %}
 {% if node.layout == "event" %}
 <div class="row eventlisting-container">
     <div class="eventlisting">
@@ -72,7 +111,6 @@ description: Upcoming and past training events from Open Knowledge activities an
         </p>
         <p class="eventlisting-eventdescription">{{ node.description }}</p>
         <a class="btn btn-primary btn-sm active" role="button" aria-pressed="true" href="{{ site.baseurl }}{{ node.permalink }}">Details</a>
-       
         <!-- {% if node.series %}
         <p class="eventlisting-seriestitle">
             An event in the <a href="{{ site.baseurl }}{{ node.serieslink }}">{{ node.series }}</a> series.


### PR DESCRIPTION
- All events page created to list all events.
- Redirect the "All training events" text of the homepage to the newly created page.
- Limit the past event list of the homepage to 10.
- Added "View all events" button at the "OKF past events" category on the homepage.

All events page
![image](https://user-images.githubusercontent.com/3656268/189706377-2eff2bb8-040d-407c-87a6-7bef7684ce67.png)

Limit the number of past events with button links to all events page
*Note: Screenshot of test with 2 events, in real code the 10 recent events are displayed.
<img width="928" alt="image" src="https://user-images.githubusercontent.com/3656268/189706866-17943cba-e4bc-4a2c-9d21-3c0a841b56ab.png">
